### PR TITLE
Adding the tools container CP7.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -283,3 +283,16 @@ services:
             CONTROL_CENTER_KSQL_KSQL_URL:
         ports:
             - 9021:9021
+
+    # tools:
+    #     image: cnfltraining/training-tools:7.5
+    #     restart: always
+    #     hostname: tools
+    #     container_name: tools
+    #     volumes:
+    #         - ${PWD}:/apps
+    #     environment:
+    #         CLASSPATH: "/usr/share/java/monitoring-interceptors/monitoring-interceptors-7.5.3.jar"
+    #     working_dir: /apps
+    #     command: /bin/bash
+    #     tty: true


### PR DESCRIPTION
I have added the updated (CP7.5) tools container to the docker-compose.yml commented to avoid downloading this ~2GB container.

If needed for doing the labs locally, uncomment the tools container block.